### PR TITLE
fix(commands): String#formatted(Object...) is an API that is part of …

### DIFF
--- a/src/main/java/ga/enimaloc/displug/internal/managers/CommandManager.java
+++ b/src/main/java/ga/enimaloc/displug/internal/managers/CommandManager.java
@@ -271,7 +271,7 @@ public class CommandManager extends DManager<String, Command> implements EventLi
 
                     event.getJDA().getEventManager().handle(new CommandExecuted(event.getJDA(), command, context));
                 } catch (Exception e) {
-                    logger.warn("An error as occurred when executing command (%s)".formatted(command.getName()), e);
+                    logger.warn(String.format("An error as occurred when executing command (%s)", command.getName()), e);
                 }
             }
         }


### PR DESCRIPTION
…a preview feature

`String#formatted(Object...)` is a preview feature for removal, we use `String.format(String, Object...)` instead

Modified:
- CommandManager